### PR TITLE
Update composer.json to allow auto-updating of campaignmonitor/create…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require" : {
         "php": ">=5.4.24",
-        "campaignmonitor/createsend-php": "v4.0.1",
+        "campaignmonitor/createsend-php": "~4.0",
         "doctrine/common": "~2.2,>=2.2.3"
     },
     "autoload" : {


### PR DESCRIPTION
It appears Campaign Monitor has released a few updates to createsend-php, but this bundle doesn't request them.  This minor change to the composer.json file should allow for auto-updating of createsend-php within version 4.
