### PR TITLE
fix: allow 202 as valid http status code of response

### DIFF
--- a/Service/Invoker.php
+++ b/Service/Invoker.php
@@ -79,7 +79,7 @@ class Invoker
             );
         }
 
-        if ($data->http_status_code != 200 && $data->http_status_code != 201) {
+        if (!in_array($data->http_status_code, [200, 201, 202])) {
             throw new Exception($data->response->Message, $data->response->Code);
         }
 


### PR DESCRIPTION
When sending smart transactional emails via the Campaign Monitor API, the HTTP response code will be a 202 as you can see in the documentation (https://www.campaignmonitor.com/api/transactional/#send-smart-email). I guess this is also true for other cases.